### PR TITLE
FIx: Fix filename case import of rwanda.json  for linux systems (Rwan…

### DIFF
--- a/src/rwanda.ts
+++ b/src/rwanda.ts
@@ -1,6 +1,6 @@
 // file location: src/data/Rwanda.ts
 
-import rwandaData from '../Rwanda.json';
+import rwandaData from '../rwanda.json';
 
 // types
 


### PR DESCRIPTION
On linux systems, import of ../Rwanda.json from rwanda.ts file create an error as the file name is rwanda.json (case-sensitive file systems).
This issue doesn't happen on windows and macos as they are not case-sensitive for file system.